### PR TITLE
Few fixes, improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,21 @@ it with the command-line tool [cv](https://github.com/civicrm/cv).
 git clone https://github.com/civicrm/org.civicrm.mosaicomsgtpl.git
 cv en mosaicomsgtpl
 ```
-
-## Usage
+## Normal Usage
 
 Simply enable the module. All ordinary tasks should be handled automatically.
+
+CiviCRM Message Templates have both a *name* and an email *subject*, but Mosaico templates do not have a subject. By default the name of the Mosaico template will be used for both the message template name and also its subject. This might or might not be appropriate to your use case.
+
+As a work-around, you can use the format `title | subject` to specify your Mosaico template name. e.g.
+
+| Mosaico Template Title                    | Message Template Title   | Email subject     |
+| ----------------------------------------- |--------------------------| ------------------|
+| Welcome supporter                         | Welcome supporter        | Welcome supporter |
+| Thanks - existing donors \| Well hi there | Thanks - existing donors | Well hi there     |
+
+
+## API Usage
 
 System administrators and developers may wish to use the synchronization API:
 
@@ -56,3 +67,4 @@ System administrators and developers may wish to use the synchronization API:
  * Synchronization is one-way. To make changes, you should only use the Mosaico template editor.
  * When you load a Mosaico template into a richtext editor (such as CKEditor or TinyMCE), you should tred
    carefully: only make small changes to the text. Changing the layout in a substantive way would be difficult.
+

--- a/api/v3/Job/MosaicoMsgSync.php
+++ b/api/v3/Job/MosaicoMsgSync.php
@@ -51,15 +51,11 @@ function civicrm_api3_job_mosaico_msg_sync($params) {
       // cool feature ("Initial welcome email").
       //
       // We allow the Mosaico title to include a subject following the | symbol.
-      list($title, $subject) = preg_split('/\s*[|]\s*/', $existingMosTpl['title']);
-      if (empty($subject)) {
-        // Default to old behaviour.
-        $subject = $title;
-      }
+      preg_match('/^(.+?)\s*[|]\s*(.+)$/', $existingMosTpl['title'], $_);
       $createParams = [
         'msg_html'    => _civicrm_api3_job_mosaico_msg_filter($existingMosTpl['html']),
-        'msg_title'   => $title,
-        'msg_subject' => $subject,
+        'msg_title'   => empty($_[1]) ? $existingMosTpl['title'] : $_[1],
+        'msg_subject' => empty($_[2]) ? $existingMosTpl['title'] : $_[2], // default to title, as before.
       ];
 
       // When a template is created from a Mosaico Base Template, it will not have a msg_tpl_id.

--- a/api/v3/Job/MosaicoMsgSync.php
+++ b/api/v3/Job/MosaicoMsgSync.php
@@ -10,7 +10,13 @@ use CRM_Mosaicomsgtpl_ExtensionUtil as E;
  * @see http://wiki.civicrm.org/confluence/display/CRMDOC/API+Architecture+Standards
  */
 function _civicrm_api3_job_mosaico_msg_sync_spec(&$spec) {
-  $spec['id']['api.required'] = 0;
+  $spec['id'] = [
+    'description'  => 'If given, only this template is sync-ed, otherwise all Mosaico templates are processed.',
+    'api.required' => 0,
+  ];
+  $spec['is_new'] = [
+    'description' => 'If true, the msg_tpl_id will be set to zero so that using Copy to create a new template does not duplicate the msg_tpl_id.',
+  ];
 }
 
 /**
@@ -34,24 +40,50 @@ function civicrm_api3_job_mosaico_msg_sync($params) {
 
     foreach ($existingMosTpls['values'] as $existingMosTpl) {
 
-      if (isset($existingMosTpl['msg_tpl_id'])) {
-        civicrm_api3('MessageTemplate', 'create', array(
-          'id' => $existingMosTpl['msg_tpl_id'],
-          'msg_html' => _civicrm_api3_job_mosaico_msg_filter($existingMosTpl['html']),
-        ));
+
+      // Handle common parameters for things that can be updated...
+
+      // Split the Mosaico message title into title and subject.
+      //
+      // This is a big ugly, but Mosaico templates do not store a subject.
+      // Being able to edit the subject of a message template is essential, but
+      // being able to administer templates by an internal name is also a very
+      // cool feature ("Initial welcome email").
+      //
+      // We allow the Mosaico title to include a subject following the | symbol.
+      list($title, $subject) = preg_split('/\s*[|]\s*/', $existingMosTpl['title']);
+      if (empty($subject)) {
+        // Default to old behaviour.
+        $subject = $title;
+      }
+      $createParams = [
+        'msg_html'    => _civicrm_api3_job_mosaico_msg_filter($existingMosTpl['html']),
+        'msg_title'   => $title,
+        'msg_subject' => $subject,
+      ];
+
+      // When a template is created from a Mosaico Base Template, it will not have a msg_tpl_id.
+      // However when a template is created from a Copy of a MosaicoTemplate, it will come in
+      // with the original MosaicoTemplate's msg_tpl_id, which is not what we want. Consult
+      // `is_new` to determine this case (which is set in the post hook if the op was 'create').
+      $isNewTpl = !isset($existingMosTpl['msg_tpl_id']) || !empty($params['is_new']);
+
+      if ($isNewTpl) {
+        // Need to create a new MessageTemplate.
+        $createParams['is_reserved'] = 1;
+        $createParams['msg_tpl_id']  = 0; // We set this later.
       }
       else {
-        $newTpl = array();
-        $newTpl['msg_title'] = $existingMosTpl['title'];
-        $newTpl['msg_subject'] = $existingMosTpl['title'];
-        $newTpl['msg_html'] = _civicrm_api3_job_mosaico_msg_filter($existingMosTpl['html']);
-        $newTpl['is_reserved'] = 1;
+        // Editing an existing MosaicoTemplate.
+        $createParams['id'] = $existingMosTpl['msg_tpl_id'];
+      }
 
-        $newTplResult = civicrm_api3('MessageTemplate', 'create', $newTpl);
+      $result = civicrm_api3('MessageTemplate', 'create', $createParams);
 
+      if ($isNewTpl) {
         // We're likely called after updating a MosaicoTemplate... don't recurse...
         CRM_Core_DAO::executeQuery('UPDATE civicrm_mosaico_template SET msg_tpl_id = %1 WHERE id = %2', array(
-          1 => array($newTplResult['id'], 'Positive'),
+          1 => array($result['id'], 'Positive'),
           2 => array($existingMosTpl['id'], 'Positive'),
         ));
       }
@@ -62,7 +94,6 @@ function civicrm_api3_job_mosaico_msg_sync($params) {
 
   return civicrm_api3_create_success(array('processed' => $count), $params, 'Job', 'mosaico_msg_sync');
 }
-
 /**
  * Filter the HTML content.
  *

--- a/mosaicomsgtpl.php
+++ b/mosaicomsgtpl.php
@@ -4,7 +4,7 @@ require_once 'mosaicomsgtpl.civix.php';
 use CRM_Mosaicomsgtpl_ExtensionUtil as E;
 
 
-function mosaico_civicrm_post($op, $objectName, $objectId, &$objectRef = NULL) {
+function mosaicomsgtpl_civicrm_post($op, $objectName, $objectId, &$objectRef = NULL) {
   if (($op === 'create' || $op === 'edit') && $objectName === 'MosaicoTemplate') {
     if (Civi::settings()->get('mosaicomsgtpl_suspend')) {
       return;

--- a/mosaicomsgtpl.php
+++ b/mosaicomsgtpl.php
@@ -10,7 +10,8 @@ function mosaicomsgtpl_civicrm_post($op, $objectName, $objectId, &$objectRef = N
       return;
     }
     civicrm_api3('Job', 'mosaico_msg_sync', array(
-      'id' => $objectId,
+      'id'     => $objectId,
+      'is_new' => ($op === 'create'),
     ));
   }
 }


### PR DESCRIPTION
Hi Tim,

Thanks for publishing this extension. I'm about to start using it in the real world (!!) and have developed a few extras for it. Sorry to have munged a couple of issues together in on commit, would have been nicer to separate in case you don't like one of them...

1. There was - what looked like - a mis-named hook instance. Might have caused a name collision.

2. There was an issue when a Mosaico template was cloned/copied in that this was copying over the ref to the original message template, but it should create a new one.

3. The subject/title of the message template was set once at creation and could then not be edited at all (because of the `is_reserverd` flag). I've changed this behaviour so that these fields are updated any time the Mosaico mailing is edited, and also so that you can specify a separate `msg_title` and `msg_subject` in the Mosaico title text by separating the subject with a `|` symbol.

I checked your tests still worked and added tests for this new stuff. Take a look.

Hope you're well,
Rich